### PR TITLE
Fixed metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,6 @@
       "name": "puppetlabs/stdlib",
       "version_requirement": "\u003e\u003d 2.2.1"
     }
-  ],
+  ]
 }
 


### PR DESCRIPTION
Puppet 4 seems to be more strict with metadata files and throws a warning about this file:
`Warning: katello_client has an invalid and unparsable metadata.json file. The parse error: 757: unexpected token at '{
  "name": "Craft-katello_client",
  "version": "0.1.2",
  "author": "Ian Henry",
  "summary": "Module for managing katello content subscriptions.",
  "license": "GNU GPLv2",
  "source": "https://github.com/Craft---/puppet-katello_client",
  "project_page": "https://github.com/Craft---/puppet-katello_client",
  "issues_url": "https://github.com/Craft---/puppet-katello_client",
  "dependencies": [
    {
      "name": "puppetlabs/stdlib",
      "version_requirement": "\u003e\u003d 2.2.1"
    }
  ],
}`